### PR TITLE
Interactive file to test image fetch

### DIFF
--- a/testGEEpull.ipynb
+++ b/testGEEpull.ipynb
@@ -1,0 +1,403 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import shapefile\n",
+    "import pandas as pd\n",
+    "#ee.Authenticate(force=True)\n",
+    "ee.Authenticate()\n",
+    "#ee.Initialize(project = 'ee-fortschthomas52')\n",
+    "ee.Initialize(project = 'ee-davidmkahler-limpopo')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Determine Area of Interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mamba, KNP\n",
+    "sf = shapefile.Reader(\"/Volumes/dmk/gis/limpopo/kruger/logger_sites/reference_polygons/mamba/mamba.shp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Balule, KNP\n",
+    "sf = shapefile.Reader(\"/Volumes/dmk/gis/limpopo/kruger/logger_sites/reference_polygons/balule/balule.shp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Paul Kruger Gate, KNP\n",
+    "sf = shapefile.Reader(\"/Volumes/dmk/gis/limpopo/kruger/logger_sites/reference_polygons/kruger_gate/kruger_gate.shp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lower Sabie, KNP\n",
+    "sf = shapefile.Reader(\"/Volumes/dmk/gis/limpopo/kruger/logger_sites/reference_polygons/lower_sabie/lower_sabie.shp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hanover, VA, USA\n",
+    "sf = shapefile.Reader(\"/Volumes/dmk/gis/limpopo/kruger/logger_sites/reference_polygons/virginia/hanover.shp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shapes = sf.shapes()\n",
+    "points = shapes[0].points\n",
+    "aoi = ee.Geometry.Polygon(points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Debug Code\n",
+    "This code works one step at a time and produces an RGB image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "startDate = \"2024-06-16\"\n",
+    "endDate = \"2024-06-21\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pull image\n",
+    "image = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED')\\\n",
+    "        .filterDate(startDate, endDate)\\\n",
+    "        .select('B2', 'B3', 'B4', 'B8', 'B11')\n",
+    "         #.filterMetadata('CLOUDY_PIXEL_PERCENTAGE', 'less_than', 10)\\\n",
+    "mosaic = image.median().reproject(crs='EPSG:32736', scale=10) # This allows us to set the resolution.\n",
+    "band_arrs = mosaic.sampleRectangle(region=aoi, defaultValue = 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Timestamp:'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/davidkahler/opt/miniconda3/lib/python3.9/site-packages/eerepr/repr.py:57: UserWarning: Getting info failed with: 'Date: Parameter 'value' is required.'. Falling back to string repr.\n",
+      "  warn(f\"Getting info failed with: '{e}'. Falling back to string repr.\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>&lt;ee.ee_date.Date object at 0x12f03e850&gt;</pre>"
+      ],
+      "text/plain": [
+       "<ee.ee_date.Date at 0x12f03e850>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Datetime:'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>&lt;ee.ee_string.String object at 0x12ef06430&gt;</pre>"
+      ],
+      "text/plain": [
+       "<ee.ee_string.String at 0x12ef06430>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Determine date of image\n",
+    "single = ee.Image(image)\n",
+    "ee.Date(single.get('system:time_start'))\n",
+    "#display('All metadata:', image)\n",
+    "\n",
+    "# ee_date = ee.Date(single.get('system:time_start'))\n",
+    "# display('Timestamp:', ee_date)  # ee.Date\n",
+    "# display('Datetime:', ee_date.format())  # ISO standard date string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get individual band arrays.\n",
+    "band_arr_b2 = band_arrs.get('B2')   # Blue\n",
+    "band_arr_b3 = band_arrs.get('B3')   # Green\n",
+    "band_arr_b4 = band_arrs.get('B4')   # Red\n",
+    "band_arr_b8 = band_arrs.get('B8')   # NIR\n",
+    "band_arr_b11 = band_arrs.get('B11') # SWIR\n",
+    "# Transfer the arrays from server to client and cast as np array.\n",
+    "b2 = np.array(band_arr_b2.getInfo())   # b2  Blue\n",
+    "b3 = np.array(band_arr_b3.getInfo())   # b3  Green\n",
+    "b4 = np.array(band_arr_b4.getInfo())   # b4  Red\n",
+    "b8 = np.array(band_arr_b8.getInfo())   # b8  NIR\n",
+    "b11 = np.array(band_arr_b11.getInfo()) # b11 SWIR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAGeCAYAAAC5LpvRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAzLUlEQVR4nO3dbYxc5X028OucMzNnZndnx+u3XS82xBRDlfgBEUh5nDfcpLbkVoiUL1WJIqq2UogBxeIDrfGHbCrVC/5gOZIJLW1EkSrL+dCQ5kNDvVLBbmTxyCb4wTIVfdI4sICXtc3uzuzuvJ1z7ucD7CaLPdff65f4xlw/aT+w98yZ+9znzH8Onuv8N3DOOYiIiHfCqz0BERE5PxVoERFPqUCLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4qnc1Z7AR2VZhnfffRflchlBEFzt6YiIXHbOOdRqNQwODiIMyXWyu0Keeuop96lPfcrFcew++9nPukOHDl3Q80ZHRx0A/ehHP/q55n9GR0dpPbwiV9A//OEPsW3bNnz/+9/HF77wBfz93/89tmzZgtdffx3XX389fW65XAYArL7pBoTR+T9ZnHFhbf27TRTxcZczXsBatrTNx43/M2gnKd98yneg5wL+x2NgaRcdX1Xm4416nY6Pnq7xCeT5JAfimI6vXVqg472FPB1v8yXG5HRCx13aouPTxinSVyjS8Qnjf25Lxg6kGZ9fNx0FAuNNlrPeRADCHH8nBqmj49PgxyAf8jnkAv761ekmHc+MY1gM+RpFhVLHsVaS4tlDP5+vd51ckQK9e/du/MVf/AX+8i//EgCwZ88e/Pu//zuefvppDA8P0+fO/bNGGIVXrEAbxxWuw+v+xgOMVzDe/UaBDo3+VQ789aOAPx8Acjm+jXyenxpp25iDtYYRX4O8UQDiPB8vGuPs/yoBoJAzjkHAt18w3lkFY/0LxluzYBziNLO2z4W/jQJtnKct8PHCJRZo6xhYBbpgFeicXV6tf8a97F8StlotvPLKK9i8efOC32/evBmHDx8+5/HNZhPVanXBj4iIXIECfebMGaRpiv7+/gW/7+/vx9jY2DmPHx4eRqVSmf9Zs2bN5Z6SiMjH0hWL2X300t05d97L+e3bt2Nqamr+Z3R09EpNSUTkY+Wy/xv08uXLEUXROVfL4+Pj51xVA0Acx4iNL4RERD6JLnuBLhQKuOOOOzAyMoI//uM/nv/9yMgI7r333gveTpRkCDt8R5Aa/zhvfYeXGl+ABElGx8PQ+IY/4ssaGt8hxpf4HWXGpw8AmJrmSZNKD99Il5F0uW55Dx1vJNYXQHTYXIQk4RuIQ75/S4p8fs2MX1QUUn6OlIwvyM42eQqjYHwRbXyHicj4Ag4ZH59N7KhQl/FFccE40UPji+i2MYd6wI+x8R0iCsZXqW0jZRKSNJdLjSLwoSuS4nj00UfxjW98A3feeSc2bNiAZ555Bm+99RYefPDBK/FyIiLXpCtSoP/kT/4EZ8+exd/8zd/g1KlTWL9+Pf7t3/4NN9xww5V4ORGRa9IVu9V769at2Lp165XavIjINU/NkkREPKUCLSLiKRVoERFPqUCLiHjKu37Qc7IgAzrFHI1mQoHRKCYyctAusjKiRr7S6mNtfCwGgXVYjEY+RiMiAJhq830YPTNFx2/o4znnngrvhjc7PU3HJxOeA843+BqUAt7NblnBaFJjHIJkskHHKxXerS5o8Rxs1OY59YbRrGilESR/v8nXL+IRX7Rhh+1bCd9Is210HOxYAD6QWjlr430YGTnszOi2Z91P4cgSsbHfpCtoERFPqUCLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDzlbQ46yVKEHfK+mZGDzlk55ojnL60cc2AGmXnI0Rn5ztDImIbG/mWJ/Qc9M2OO03We032/m/9V76zFc8JTxl/Nzhl/1dTqxdtt5IT7jKAzTzEDUZn3g16a5+fYWcfXt1Dn82+0eU68nu/8F6UBIDSCuE3rj85af3UXQNPo+Z0GRs/rgnE/g3EMjVMcQd64n8LouV0wmm7nyB9eJq2iF9AVtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYHDTgg6JCDNnLEidHHNTQytPmQZ1hhxIyd0SfWymemAc9fhuDzcxeQUYXjQcy6kYN+5yzPQUdGDhip1SuYH8O6ceo2e/jzawW+f0GOP7+c5znoVpvv31jL6CmeGfMzDnHDOH7FHr5+LaNfeGDdawCgRHLAAOCMrHpgZLWTjM+hkfLnF437IYoxn3+7Q32aE7jOBykwnjtHV9AiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeMrbHHQUhgg75XmNftChkYNuGvnIwMghR8Z4YPSJdVaQOjTGM2v+RtAaF5DDzPGM6OxUk28/x3PWVlQ7tI5xyI9BLuRrcCbu4RPgMWYEReP1C3wH4xbPyp82ctiuZfVE5/vfl+cdr7PY6Pd9Add21iMCoyd2avRlzxJ+kIKMn4PtWf76bSMHbe1hRE6iljH3C3sFERG5alSgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYH3dOdRxSd//PDaKULGDln1zDylwkfh9GPOgqNftDGeHYh/ZzZ69sxaIQhP/RRzDeStXlWuznLM6ilmO9jLjZ6XhtZ9MQ4hi0jK26dAtYZUi7w9Vne5ut/eprnzOtGL2Srl3Kt2qLjOeMcTY0cOgDA6PfcNu5XiKxjBONEJ/2YASA1epKjad1vwI9hQNYoM2vMB3QFLSLiKRVoERFPqUCLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinvM1BVwpF5HLnz1E2M6OPq+P5xtjIAM82eQa1ZcQn04x/7oU5I2NsRCRD43M1Cy6kV6+RQTV6UmddfPsFI4ebL/Bj0NVToOPNOj9GidFPumFkbIMiz2FbDa3fN/o1l/N8fa/vjen4mzWeM49SfhJNtPj6RXm+f11GxhgAGkZa3MpqW/cbWOdw3qhuDaMlemBsP5fj+xeTftah4/s2/7gLepSIiPzWqUCLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDzlbQ66u5BDvkMOOq4bQeSIZ2iTAs9fFnkEFRPT/PUbCR/PHM/Ahkaf3CzkGVgYOW8ARsITCI2cay7PFynq5XPIjF68OSMm6iK+/elWg47P1ngO+P1uvv1Gwo/BWSPMvqa7SMe7uvk53Gv0E3YtvoBWL+bUyFE3zTMIiFJ+nueMnt5ZyLPopcjoy57jzw+NxunO6LkdGyepIzno6ALWD9AVtIiIt1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYHvbIco9ChoesZo98zMp5PzBv5yB7wDGoMnrE90+Dzm2626HhmHBZn7B+c0VAaACLjszk0+iVbvXSNfseZkQNtGK2Clxr9pNHdQ4dzRob1zTo/xiW+e1hi5Iwnmvwcua7Cc9KtzDhHjH7P/AwEeoz3SJZZvZyBxHifhh3uc5gTGDnk1Gj4bOWYQytHbV6+8udnJAdtvYXn6ApaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpFWgREU95m4PujUuIO+QcXYn34j1d4xnWXIF/LhWNfGR3oYuOV2KeQ35zxsjIzhq9fo0YuBHP/GAbRk43l+NZ8HyOH4OsZfS8NjKwjYTnbCeMIHa3kXOuVfn8J1I+vqS3RMdLRo54yjhHG2mNjoeBkeVv8nMoNNYniPj6ti7g0i5K+TFsGmHg2DiRc1bfdOMcSY1zzIV8JzPw5+fJGgcXkCMHLuIK+tChQ7jnnnswODiIIAjw4x//eMG4cw5DQ0MYHBxEqVTCxo0bceLEicW+jIjIJ96iC/TMzAxuu+027N2797zju3btwu7du7F3714cOXIEAwMD2LRpE2o1fkUgIiILLfqfOLZs2YItW7acd8w5hz179mDHjh247777AADPPfcc+vv7sW/fPnzzm9+8tNmKiHyCXNYvCU+ePImxsTFs3rx5/ndxHOPuu+/G4cOHz/ucZrOJarW64EdERC5zgR4bGwMA9Pf3L/h9f3///NhHDQ8Po1KpzP+sWbPmck5JRORj64rE7IKPdHFyzp3zuznbt2/H1NTU/M/o6OiVmJKIyMfOZY3ZDQwMAPjgSnrVqlXzvx8fHz/nqnpOHMeI4/hyTkNE5JpwWQv02rVrMTAwgJGREdx+++0AgFarhYMHD+LJJ59c1LbGJmeR75CVva6X98p1xv8YTM3W6XguMHLSJf6B0mV84ORioxdxzP8d/swUD0JnFxBSzYx9zFKeo02Nfs5ZZPSTNjKwUchzvjNGr99Km+esXcifH9R4x+QZx8ddyVg/HjMH2nx+S4z1bRhZ/mLA51dP+fOTzGiIDQDGNlIj0J8v8Oc3jRwyMuN+goy/B6zi6AL++rMk6t5KLqBn+wXM4RzT09P4xS9+Mf/fJ0+exLFjx7B06VJcf/312LZtG3bu3Il169Zh3bp12LlzJ7q6unD//fcv9qVERD7RFl2gjx49it///d+f/+9HH30UAPDAAw/gn/7pn/DYY4+hXq9j69atmJiYwF133YUDBw6gXC5fvlmLiHwCLLpAb9y4Ec51/t+vIAgwNDSEoaGhS5mXiMgnnpoliYh4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp7xt2D81OY1cdP4wfF/XEvrcpT38LoC2cZPCTJU3U0fIm7lXuviy3rCsj46Xe/iNOCdaZ+n4eGrMHwCMG0WyhH92t/gSwuiVjlxo3MQQ8psArOfPhvxGgE5/DGJOybhJYrbJz4GqcSNCXOLrm3Y49+c0jYbvgXEjTzHir183jl94AQ3n88aNIJlxDJ1xI0vgjDW09sFYA+vvYljHICQ3eyXGjWDz27igR4mIyG+dCrSIiKdUoEVEPKUCLSLiKRVoERFPqUCLiHhKBVpExFPe5qCjfA5Rh4b949Oz9Lk5Hq9ETxdvqN8wmqnX6jwDGxgZ4pUxf4Ebly6h487x/OXMydN0HABm6jzl6YyG/CAdDQHAGTlcKwYaZEYKNeKnbi3hr19v8AkEBf4HA5yRks1afDwpGjlr4xxOjZw1P0OBnoDvX3fOuHZL7Rx0oZuPZ0bT/9Q4h4I8X6SwZfxRgxb/owuAcRCMJQjI7nX4C4Dn0BW0iIinVKBFRDylAi0i4ikVaBERT6lAi4h4SgVaRMRTKtAiIp7yNge9vKuEQu7805ut837HZ9ImHQ+M/GLByMCmRoi3nvIU6uT0DH99I3+5tsz7SY8vr9NxAHhjfJqOJ0a/YysjGqZWzpqvcWD0gw7AM6wu5Fn36ZQ/33pjFIxex/WUr0+jxten2+gXHRb4DCNj/epGP/AlAd++67H7GedTvg9F4xyaMfahbWSx80Wesy40+PNdaPSLNvpB5/KdX9+K+c/RFbSIiKdUoEVEPKUCLSLiKRVoERFPqUCLiHhKBVpExFMq0CIinvI2B91OWgDOn7V0RpB5VU+JjrcSHkKs1vn2VxSLdHymzjO2tTrPaRvtnrEi4o12r1/eyzcA4O0qz0FPJTxDitToF230k86c0U/ZyBE7o6GulaMukIwqAMB4/STHj2GuYMzfyPA220ZG1zhH8rHRr9voR10z5leasXPQDauldGD07DbGwxYfLxvHsBzyvuxZl9Gze5afAy3Sc7xl9POeoytoERFPqUCLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDzlbQ767doMctH5Pz+ikGdYB0t8PM7x/OPpySodb3ToUz3nukoPHT87w/tBt4wM6vQsz1l39fD9A4BV5TIdn52YpONNHhFFZuSgrSCvEYFF2ubXFlHA+1kHeX4MjQgtsqaRozZy3nHEXz9fNPoxT/Oe3zWjp7kz7gWYyfMFuC5vX9sFRs9so6U3kg73QcyPG33ZW+DnWDXP16Bg9Myu1fk5xspQ25j7HF1Bi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpb3PQM402og456GbCA5SNjGcMewo8w1owMqqVmPeDHujjOWjHI6o4Xa3R8WbTyGEv4/MDgJuX8Dn+8jTPgrsGz5imGR8PMx50joyseWr0BA+MnG8SGv2SjbdG1jIyuE0jq97He3p39fCTpFbjvYjbLaPfdGOWjsddPEu/opf3XAeAipElrzkjCB3wY2AcQjSMMH1q5Jjz3XwNeo2sesDuZ7AmP/ewC3qUiIj81qlAi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ85W0OuhiFHftBJwnPL1ZnG3S82eI56Ot6ea/ktMEzqO83eAa3FPCMa3feCEobGeN8wQigAigbOehuI+PZSHg/YrSNnHTCrw0yo58yOpwbc8KAr4Fr8RxqaOSsXc7Icad8/aLQmJ+R9UfMh4M6337dOEfTBs9514ye6gDMORZDvkZdMR9vN41jyF8ejbbRb9rI6hdC/vxp0s+6bfS6nqMraBERT6lAi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ85W0OeklXEbno/HllZ7RSrRoZUiM+iTTlDxhv8wzpzNkpOl4xeh0vW1rh25/mOe+0aeego4g/plTgn92B0VM7Al/DNuuVC8A5/vqRcQxdyLcP8P3PMmMNc3x+ubyR4TW2vyLgOeOwl69/PeU59STm2y8Yyzc+w+8FAIAw5H3Ju2O+hqlxDiHgz4+NLH0z5sdgaoa/z6IyX8MyOweMnP4cXUGLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4ilvc9C9xS7kcx2ynlaGtsE/d+qO92Kt1mbpeLGb5zuzjOew0xyf/3LXTcf7lvDXtzPAQJLwNQiMnGauxE+dprHGaPE5BlYE1lk5ap4ThtFuOcjz7YdGTtvK6CZGP+g04Ot70+AyOn4me4+ON6Z5jnmZcY7PXEAOesLom448bxidM254KBn3I+SNNV5hZMFPt/n8p2q8L32p2Hn7aXIFctDDw8P43Oc+h3K5jJUrV+JrX/sa3njjjQWPcc5haGgIg4ODKJVK2LhxI06cOLGYlxERESyyQB88eBAPPfQQXn75ZYyMjCBJEmzevBkzMzPzj9m1axd2796NvXv34siRIxgYGMCmTZtQq9Uu++RFRK5li/onjhdeeGHBfz/77LNYuXIlXnnlFXz5y1+Gcw579uzBjh07cN999wEAnnvuOfT392Pfvn345je/ec42m80mms1f/69EtVq9mP0QEbnmXNKXhFNTH/ScWLp0KQDg5MmTGBsbw+bNm+cfE8cx7r77bhw+fPi82xgeHkalUpn/WbNmzaVMSUTkmnHRBdo5h0cffRRf/OIXsX79egDA2NgYAKC/v3/BY/v7++fHPmr79u2Ympqa/xkdHb3YKYmIXFMuOsXx8MMP47XXXsPPfvazc8Y+mgBwznVMBcRxjDg2/vyviMgn0EVdQT/yyCP4yU9+ghdffBGrV6+e//3AwAAAnHO1PD4+fs5VtYiIcIu6gnbO4ZFHHsHzzz+Pl156CWvXrl0wvnbtWgwMDGBkZAS33347AKDVauHgwYN48sknFzWxcrGAQoe+yaUczxDmZ2foeHWah2CTlOcrszwdRiPgGdqZ6Wk6vmK2TMfX9ffQ8akG72MLAGff52uUM/oVxzE/ddKU56CzhjFuZN3hjH7OxvOtds9hauTAjZx4AP76beMceW+S93NeVemi48t7ltDxNOLn4M39PGc9PcmfDwCvneZ90dMqv9+gQnLEABBF/I1YMNY4CHnOutLHs+DRrBWmJ+eIcf7OWVSBfuihh7Bv3z7867/+K8rl8vyVcqVSQalUQhAE2LZtG3bu3Il169Zh3bp12LlzJ7q6unD//fcv5qVERD7xFlWgn376aQDAxo0bF/z+2WefxZ/92Z8BAB577DHU63Vs3boVExMTuOuuu3DgwAGUy/yqUEREFlr0P3FYgiDA0NAQhoaGLnZOIiICNUsSEfGWCrSIiKdUoEVEPKUCLSLiKW/7QaOddswK5gu81293yPOThS6+2+OzPINaneHjnfLbc/JGxnaqxfOVE0aOu2DktAHAhTzrXTA+u4sp/8K42amX95yIj4fg27f6VWeZ1W+ajyeZce2S8Pnncnz+1pVRmuM58TcneFOx/33jIB3/TNxHx7sDfhK9E9mBgV9O85zzjJEFzhf4+7gr4HcgZ03+Pg27S3T85gpfg3oP7wddn+m8Rk2jH/scXUGLiHhKBVpExFMq0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4ilvc9CNJEHWIQubC/jnSsnoI4smzxGXYp5/bLV4hjEy5tdb6qbjidGU6u0z79PxW1atoOMAsKa3l45PGPtYnea9fkMj5hlZOWljAwWjna5r8we0Ez7ujGPoMj4/Z8VcA77/bR5Tx0S9ScenjF7Fn+pfTsfrNZ4hbhm9lAHAGYe4Pcu3UQ35PkQxf4FSwA9CYGSRg8C4nyLH60Qt33n7iZHzn6MraBERT6lAi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ85W0OOnEOQYc8cB48wxrH/HOnbQQ0V+V5n9hKm/ehnU2Mfs1GTLud8D6zv6zyXsCFIp8fANy0lP+V9TVLeFb7/ekGHa+BjxsxXzsnGhm9hK0ccmRcm/B20UiNftKp9fpWv2gjJ900ctz/dYpn5df2Ful49zJ+/OMG7/UMAEtj/hqtFl+D00bWu+H4Mbwu5m+0mnGQ/ucsP4dXVvj7rLvUeTxn3QfwIV1Bi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpb3PQQRghCM+fFcxSnqJN23y3ekpGBjHhGdco5H1gMyMj2074/MOU50PrdSMnPTlJxwFgdbmLji/N8wzrLSuW0PHm+Bk6/l5gJKGNrLqZk7YuPax2vMY5hg7n5pxOvcznn27krEMj658Z/ZjHazN0/P+8M07Hv9R7Ix13xvwAIF/g75NyN88h1yZ4DrkxzXtWjxnvo5nYeJ9nvI70Zfw90lPs/PzMXj4AuoIWEfGWCrSIiKdUoEVEPKUCLSLiKRVoERFPqUCLiHhKBVpExFPe5qCjKEPO6PnbSYc20vOKRo45zfF8ZpLx/GQ55svaavLtT6c851zI8fk3G1bIF5iY4RnTltFQuRDyYzNY5v2mJxt8HxMjix4YOeOULxHSwNi+EYMOjFMzMLafGf2i20bOODRy2KnRT/q/x3k/51L+XTr+mRuW0nEAWL7M6Pf8yxodt/axEPGDfMbISU9O8b7ta1byfSzk+Ps8lyf9oI1e1nN0BS0i4ikVaBERT6lAi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp7zNQRfCCIUOOciGkSMOIj7uIt7HNWnzfKRzPKPaad7zzzdy1jCGczlj+1YvYwD/fWaKTyHj2+gpdc54AkBfma/x6i4+/v9a03Q8zYxri9A4R4yGvJlxjK0gcxDxYxQYWXoriB2Y/ZitLD/PEP/POM8or+0rGa8PlGN+jOuTRlY8Mu4H6OHn4FJn5JSzAn9+wOffNm64aJGsPt+zX9MVtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYHnWUpOkVFg8Dod2zkkBtGznl2uknH80Wej0zbfH6lAs9fNttGhtXoQ9t2RsYWwKkpnjNGnu9DvcXnWIr5Z//a5Uvo+FSDH6P36ryftUt5Ttjq55wZ55hLjH7NRk45CI1rI+sQpnx+mbGDobF/1QZ/D/z8rbN0HABuWdNHx1dfx3uGn5zl+1Au8zV0df4+zcc8C140suxV4xilpOd6s23fqwDoClpExFsq0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4ikVaBERT3mbg260HNLs/FlNK8OaMzKoYZMHGGdT/rlVbPJurkUjp5waq9429q8U8flFbZ6zBoCc0S+43uI52Nki34n3qjyn/Dsr+Rw/tbSXjtdO8Zx0zYiZupSfAzkjau/y/CAZrYLhjJPY6vfsSK9hAAiNftZGy3FkRhD7nckZYwtAT4HnjFcvXULHXcT3cSLjWf6akVPOdagvczLjfTzd4GvQ2+6co24l1hH4gK6gRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKeUoEWEfGUtznoIEg75p3DPM/Q5nkbV+SM3S4Vec7Z6jXcKb89pzHDM5Ch45+buYAHPKcSI4QLoG30A27M8tcIjRzuVMjX8BdjE3R8uZGRXVVZSsfrpyfpeGqscZQzeg0b1zYu40HszMi6m5dOZkNrK4htjBv73zKOPwCcMI7B2YSfIytCIyve5DnrsFmn49UJntVvFvkxXLekRMdZz+/AWv8PLeoK+umnn8att96K3t5e9Pb2YsOGDfjpT386P+6cw9DQEAYHB1EqlbBx40acOHFiMS8hIiIfWlSBXr16NZ544gkcPXoUR48exVe+8hXce++980V4165d2L17N/bu3YsjR45gYGAAmzZtQq1WuyKTFxG5li2qQN9zzz34wz/8Q9x88824+eab8bd/+7fo6enByy+/DOcc9uzZgx07duC+++7D+vXr8dxzz2F2dhb79u27UvMXEblmXfSXhGmaYv/+/ZiZmcGGDRtw8uRJjI2NYfPmzfOPieMYd999Nw4fPtxxO81mE9VqdcGPiIhcRIE+fvw4enp6EMcxHnzwQTz//PP49Kc/jbGxMQBAf3//gsf39/fPj53P8PAwKpXK/M+aNWsWOyURkWvSogv0LbfcgmPHjuHll1/Gt771LTzwwAN4/fXX58eDj3y77Jw753e/afv27Ziampr/GR0dXeyURESuSYuO2RUKBdx0000AgDvvvBNHjhzB9773PfzVX/0VAGBsbAyrVq2af/z4+Pg5V9W/KY5jxHG82GmIiFzzLjkH7ZxDs9nE2rVrMTAwgJGREdx+++0AgFarhYMHD+LJJ59c9HaLUR6F6PyBZiujWjAyriGPT6LseJC6GfDtp0bGMbJ6ARu9fCfbPJ9ZM3o5A0DBaEod5/gipU0jy20co9N1noFt5XiGdXAJ/1CvNvn4VIPPPzPOoczIogcpP4cyI6dsnAJmFt/KOZs57sTIwUdGs2UAmfEa756dpePNEj8Hrx/so+PL6/z5b0W8n3NkLHFijNfIe6Bt9Nues6gC/fjjj2PLli1Ys2YNarUa9u/fj5deegkvvPACgiDAtm3bsHPnTqxbtw7r1q3Dzp070dXVhfvvv38xLyMiIlhkgX7vvffwjW98A6dOnUKlUsGtt96KF154AZs2bQIAPPbYY6jX69i6dSsmJiZw11134cCBAyiXy1dk8iIi17JFFegf/OAHdDwIAgwNDWFoaOhS5iQiIlCzJBERb6lAi4h4SgVaRMRTKtAiIp7yth90oRChkDv/9NopzxA2jF613eAZ2MDIKBbzfNlaxvzaVqveNn9+2ubzj61ewQBgZMELJd5ze7bBs9YzbT7eZeSkk9kWHe+tFOn4Z1cvo+MnzkzR8YkqX+PUOIZZjh8D53iW3RkvkIZ8PDCy/AiMHHtmnIOpfW3njH7OoVF9qg1+DtTO8qz89YM8PVbu4f2cRyf4OXIq4fPLTXfuN52kfP3n6ApaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpFWgREU95m4Nupw5Bh567baPXbS7kvYaDtvG5FPCQsDNy1u0mz7havWCtCGsh5fMLSvZhTVp8jZzRkNgVeb/lvoivUVbgz0+aPEcdG72CB7t66HjT6Md8osn/NmbNOMbWlU8AI6tu9BwPjX7UzhlZf6OftNmPmg9f0Bwyo695w3gfvjlZo+P5Lr4TX1i+hI4XlvLXP37mXTreTjqvUmrcKzFHV9AiIp5SgRYR8ZQKtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeMrbHHTmUnSKquZD/rlSNBrNtlIjw+p4RrFuZEgTo5du0eiF3NttzD/hr982+kUDQM3xOdQznpNuGDnOvJHjrTb4McgbazwxwXvxTs+8T8e7yrwX8I0VnqP+r/dm6Xgz4McwMK6NwoAnjY120EiM42slmQOjp/gFdByHVV4c+DmQWe9DYxJvvc+z7P9rWYWOF7p4Drqc8Z7k+XLnY5Ak6gctIvKxpgItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKeUoEWEfGUCrSIiKe8vVElch/8nI8ZYDeasbuMfy4VeD4deeMmgbBoLKtxEwBS/gLdxl0Kjbz9uZuV+F8FcPw+FbiEv0aXcTNRLs9fv1Dgx7hqNMwvGms4ZTSLX1rupuNr0iV0/Ffvz9BxZ/zRCWfcCpIZ49aNJi7k65sZ127GfUgALv3qzxk3KyHk440G38cT7zXo+PXX85uZVlb4H51wpGF/27jZbI6uoEVEPKUCLSLiKRVoERFPqUCLiHhKBVpExFMq0CIinlKBFhHxlLc56KwQIcudPyubknwhACRtHuKNjN1OeEQWoZExzecLdDwXGM3wW3z7qRFCDTK7GXg+x9egy9jHnpDnmI0YMsoxX6Mk5fuQRnwNmgFv6P/ORI2Ol3M8DP+ZwaV0vG6cRG8bf3DASslGRkN/ZzTkh+PHz2roHxo5bsD+owSB8Yc1XMjX0Bnbbwd8H0+On6bjfUtX0/FVPfyPOvzPeOdzzIjhz9MVtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYH3XQOWYesZZbyHHHC28CiAJ6xbYHnJ0MjI5rL+AS6jF7MuTxPwSZtnqENI7vXbJjxORSNfTDaRaNQNHpuF/gcZ+p8+zljF5dEPMc8keO9fE/X+QTWhkvo+PoBnpM+XXuXjs80+TkahEbTcjNIzc9hI2aNwNnXdmFghH0jfg5aPamNluNmz+3UiIK/OzZFx1tdvHxmcecJZsb6z9EVtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKe8jYHnbRSBB2iuCWzly0PgTojn5kmPINazBsZX/DthzzGjEbGt58Z/aCtftUAkAt5zjnp0It7TsnIcWaOz6HV4GsUGxnZ7hLPAZcifmoPGjHUyRY/SBMzDTp+3ZIyHf+dvhId/7+neAY3NM4RGP26c6FxjljtpK3nA2aY2sxaG0FnB34OF4xzoLeLn0MtYw1Hq7N0/Ma+JR3H2kaNmKMraBERT6lAi4h4SgVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ85W0OOstCZB2ynknIc8pxxD93UqMXci7H85VGDBmJkZ+MjJxyK+P7lxkR1Mjohw0AgdFQOXV8I1HA9zE1Qq7OyEkXjSCuEWHFeJ3nlCcznnOenuUdr98cn6Tjle5uOn7zimV0/OwU70c90eLr0zZyys5qpmy8x6yc9YevQkcDo19z2DbOAZIzBoCb+66j46dTvsa56iQdP2Vk5d+pzXQcS4x7LeboClpExFMq0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4ikVaBERT11SDnp4eBiPP/44vv3tb2PPnj0AAOccvvvd7+KZZ57BxMQE7rrrLjz11FP4zGc+s6htF0Og0OHjw6U8g5l0aiQ993xYOWU6jMDImAZG/rOVWRlh3is2MILYZsYVgNFKF2HK97GR8A1kgZFVz/NTr2nkcLMaz7C+M8Fz0O0mz7BWU2P/2vwYTU7V6PhsyM+BuKtAxwspz2k7M0tvnMMBD5o7Y/4AYMScUSzwc6DYqQB8aHl/Hx3PGW/k5nv8HGq4Jh13xg7ONDufI2l6hXPQR44cwTPPPINbb711we937dqF3bt3Y+/evThy5AgGBgawadMm1Gr8hBURkYUuqkBPT0/j61//Ov7hH/4BfX2//hRzzmHPnj3YsWMH7rvvPqxfvx7PPfccZmdnsW/fvss2aRGRT4KLKtAPPfQQ/uiP/gh/8Ad/sOD3J0+exNjYGDZv3jz/uziOcffdd+Pw4cPn3Vaz2US1Wl3wIyIiF/Fv0Pv378fPf/5zHDly5JyxsbExAEB/f/+C3/f39+PNN9887/aGh4fx3e9+d7HTEBG55i3qCnp0dBTf/va38c///M8oFosdHxd85AsI59w5v5uzfft2TE1Nzf+Mjo4uZkoiItesRV1Bv/LKKxgfH8cdd9wx/7s0TXHo0CHs3bsXb7zxBoAPrqRXrVo1/5jx8fFzrqrnxHGMOI4vZu4iIte0RV1Bf/WrX8Xx48dx7Nix+Z8777wTX//613Hs2DHceOONGBgYwMjIyPxzWq0WDh48iM9//vOXffIiIteyRV1Bl8tlrF+/fsHvuru7sWzZsvnfb9u2DTt37sS6deuwbt067Ny5E11dXbj//vsXNTGXOWQd8sLO6FXcMnqtBkaG0xm9jiOjl7E1PyNmbY5bfXbzRq9nAGgnfBvTCc+AZqnx2W70g4axxoFxZraMY9BtZGyTgOeYYaxPYlzbvD05TcdPTvIvw9vG+q3o4f/XWZ3h+9cw3gOZeRbaTce7CjxLPdBbpuOh42ucTPE1fmvqNB1v5fg50m30lS9F/PnsPXShOejL3rD/scceQ71ex9atW+dvVDlw4ADKZX4wRERkoUsu0C+99NKC/w6CAENDQxgaGrrUTYuIfKKpF4eIiKdUoEVEPKUCLSLiKRVoERFPqUCLiHjqssfsLpsQ6NT22Ig5IzJywDmjX3Iu5BldJLwXr91rl28+M/rMutToQ9vg8wMAl/EcaxzyfsQto2d1aswxafM5pkZMuaunRMf7jJ7gUwk/xmUjJzxpZHTfmea9hieqfLyvwvfvtoFldPwU6UUMAKNnefvfqnGOdwWdWz3MGajwaG1fVxcdf3dmho6nLd7zu27cj9Cc5tvP5fk50jLqhEs69xx3Rr/xObqCFhHxlAq0iIinVKBFRDylAi0i4ikVaBERT6lAi4h4SgVaRMRT3uagwyhE2KEfa7tpZHgjHjQ2hs1expmxbK5DH+s5DSPkWzAmaMQ70crsXrOR0as3NHpOZ0aOM4UxByMnnRWMXsDGPuZDntMt5Pn8Z5t8+wl4Tjho8WNcivn8rlvGM8SrV/Ac9GDI9y+X8HPszSrvB56zwvwA0jY/xrN1ngXPGePtBj9Hegr89d8/w3PQjSJ/n4chfw+V8p3vJQjchfWD1hW0iIinVKBFRDylAi0i4ikVaBERT6lAi4h4SgVaRMRTKtAiIp7yNgedJik6JUljHj9EaPRTbhgZ1yyyeiXzPrCRkRHN5fjnYtAh/z0na/H5G8MfvMZs5161AABjjrnIyIgaWe2EHyLEnZqBf8gl/AUyYw1zxpmfK/AHxBnPQZeMjOzqfp5zDo2cdbXJx1cUeD/vwSW8F/Nkkx+gU1XeTxoAzs7wHHO3kXXPGT29c/mYb98oFJUKX4OJGp+/M7L+Dp3nZ91HMEdX0CIinlKBFhHxlAq0iIinVKBFRDylAi0i4ikVaBERT6lAi4h4ytscdBZ+8HM+EXi+MRfwXrxByD+XIvAcc2g0ZE4dz0nnc0avYaNXMhL+/NToR/3BHPg+JsYaFI1+0W3j+VZOuWnsQ5jwY1wsGMfIyIpXYj6/fMLfOvkunkMeWMIzvG+e4jn1amOWjgdtvj7X96+g42GR96uuvj5FxwHgfeN+g6pxDPIhf8CSIq8DeeMcXdbFc9D1Jj8GTeMkStqdz8EsUw5aRORjTQVaRMRTKtAiIp5SgRYR8ZQKtIiIp1SgRUQ85V3Mzn3YKrRNomSZFeEKjBiaEWO75JgdHbUfYc0vNWJ27QuK8Bgxu8CI0RlJvrbRDjQ1IlBWy1irnWkUGvM31jA0jlHbyukZ228ZMThrfk3j+c1OGdUP1Y12pc0W335i7T+A1Gip6fgpaL7PrDlYa5hYLWuN+VtRuQB2zM4Z53ngrEf8lr399ttYs2bN1Z6GiMgVNzo6itWrV3cc965AZ1mGd999F+VyGUEQoFqtYs2aNRgdHUVvb+/Vnt7Hktbw0mj9Lp3WcCHnHGq1GgYHBxGSG+e8+yeOMAzP+4nS29urA3uJtIaXRut36bSGv1apVMzH6EtCERFPqUCLiHjK+wIdxzG+853vII55cxnpTGt4abR+l05reHG8+5JQREQ+4P0VtIjIJ5UKtIiIp1SgRUQ8pQItIuIpFWgREU95X6C///3vY+3atSgWi7jjjjvwn//5n1d7St46dOgQ7rnnHgwODiIIAvz4xz9eMO6cw9DQEAYHB1EqlbBx40acOHHi6kzWM8PDw/jc5z6HcrmMlStX4mtf+xreeOONBY/R+nFPP/00br311vm7BTds2ICf/vSn8+Nav8XzukD/8Ic/xLZt27Bjxw68+uqr+NKXvoQtW7bgrbfeutpT89LMzAxuu+027N2797zju3btwu7du7F3714cOXIEAwMD2LRpE2q12m95pv45ePAgHnroIbz88ssYGRlBkiTYvHkzZmZm5h+j9eNWr16NJ554AkePHsXRo0fxla98Bffee+98Edb6XQTnsd/7vd9zDz744ILf/e7v/q7767/+66s0o48PAO7555+f/+8sy9zAwIB74okn5n/XaDRcpVJxf/d3f3cVZui38fFxB8AdPHjQOaf1u1h9fX3uH//xH7V+F8nbK+hWq4VXXnkFmzdvXvD7zZs34/Dhw1dpVh9fJ0+exNjY2IL1jOMYd999t9bzPKampgAAS5cuBaD1W6w0TbF//37MzMxgw4YNWr+L5G2BPnPmDNI0RX9//4Lf9/f3Y2xs7CrN6uNrbs20njbnHB599FF88YtfxPr16wFo/S7U8ePH0dPTgziO8eCDD+L555/Hpz/9aa3fRfKu3ehHBcHCP7vgnDvnd3LhtJ62hx9+GK+99hp+9rOfnTOm9eNuueUWHDt2DJOTk/iXf/kXPPDAAzh48OD8uNZvcby9gl6+fDmiKDrn03V8fPycT2GxDQwMAIDW0/DII4/gJz/5CV588cUFfcm1fhemUCjgpptuwp133onh4WHcdttt+N73vqf1u0jeFuhCoYA77rgDIyMjC34/MjKCz3/+81dpVh9fa9euxcDAwIL1bLVaOHjwoNYTH1zJPfzww/jRj36E//iP/8DatWsXjGv9Lo5zDs1mU+t3sa7iF5Sm/fv3u3w+737wgx+4119/3W3bts11d3e7X/3qV1d7al6q1Wru1Vdfda+++qoD4Hbv3u1effVV9+abbzrnnHviiSdcpVJxP/rRj9zx48fdn/7pn7pVq1a5arV6lWd+9X3rW99ylUrFvfTSS+7UqVPzP7Ozs/OP0fpx27dvd4cOHXInT550r732mnv88cddGIbuwIEDzjmt38XwukA759xTTz3lbrjhBlcoFNxnP/vZ+diTnOvFF190AM75eeCBB5xzH0TFvvOd77iBgQEXx7H78pe/7I4fP351J+2J860bAPfss8/OP0brx/35n//5/Ht1xYoV7qtf/ep8cXZO63cx1A9aRMRT3v4btIjIJ50KtIiIp1SgRUQ8pQItIuIpFWgREU+pQIuIeEoFWkTEUyrQIiKeUoEWEfGUCrSIiKdUoEVEPPX/AStcjPp7k6+SAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Export RGB\n",
+    "np_arr_b4 = np.expand_dims(b4, 2)\n",
+    "np_arr_b3 = np.expand_dims(b3, 2)\n",
+    "np_arr_b2 = np.expand_dims(b2, 2)\n",
+    "rgb_img = np.concatenate((np_arr_b4, np_arr_b3, np_arr_b2), 2)\n",
+    "rgb_img = (255*((rgb_img)/3000)).astype('uint8')\n",
+    "plt.imshow(rgb_img)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run\n",
+    "This code runs the fuction over the date range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = pd.date_range(start= '2017-08-08' , end='2024-06-22' , \n",
+    "              freq='5d')\n",
+    "end = pd.date_range(start='2017-08-12' , end='2024-06-26' , \n",
+    "              freq='5d')\n",
+    "dates = pd.DataFrame ({'start': start ,  'end': end})\n",
+    "#print(dates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define function\n",
+    "def pulldata(startDate, endDate):\n",
+    "    # Define source data\n",
+    "    image = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED')\\\n",
+    "        .filterDate(startDate, endDate)\\\n",
+    "        .select('B2', 'B3', 'B4', 'B8', 'B11')\n",
+    "         #.filterMetadata('CLOUDY_PIXEL_PERCENTAGE', 'less_than', 10)\\\n",
+    "    \n",
+    "    # CRS is not the same.\n",
+    "    # proj = image.first().select('B2').projection() # EPSG:32656, UTM zone 56N (Siberia?)\n",
+    "    # proj = balule.projection() # EPSG:4326\n",
+    "\n",
+    "    # Export arrays\n",
+    "    # https://gist.github.com/jdbcode/f4d56d72f7fc5beeaa3859999b1f5c3d\n",
+    "    # https://gist.github.com/jdbcode/f4d56d72f7fc5beeaa3859999b1f5c3d?permalink_comment_id=3355627#gistcomment-3355627\n",
+    "    mosaic = image.median().reproject(crs='EPSG:32736', scale=10) # This allows us to set the resolution.\n",
+    "    band_arrs = mosaic.sampleRectangle(region=aoi, defaultValue = 0)\n",
+    "    \n",
+    "    # Get individual band arrays.\n",
+    "    band_arr_b2 = band_arrs.get('B2')   # Blue\n",
+    "    band_arr_b3 = band_arrs.get('B3')   # Green\n",
+    "    band_arr_b4 = band_arrs.get('B4')   # Red\n",
+    "    band_arr_b8 = band_arrs.get('B8')   # NIR\n",
+    "    band_arr_b11 = band_arrs.get('B11') # SWIR\n",
+    "\n",
+    "    # Transfer the arrays from server to client and cast as np array.\n",
+    "    b2 = np.array(band_arr_b2.getInfo())   # b2  Blue\n",
+    "    b3 = np.array(band_arr_b3.getInfo())   # b3  Green\n",
+    "    b4 = np.array(band_arr_b4.getInfo())   # b4  Red\n",
+    "    b8 = np.array(band_arr_b8.getInfo())   # b8  NIR\n",
+    "    b11 = np.array(band_arr_b11.getInfo()) # b11 SWIR\n",
+    "    if(np.max(b2)!=0):\n",
+    "        \n",
+    "        # Export RGB\n",
+    "        #np_arr_b4 = np.expand_dims(b4, 2)\n",
+    "        #np_arr_b3 = np.expand_dims(b3, 2)\n",
+    "        #np_arr_b2 = np.expand_dims(b2, 2)\n",
+    "        #rgb_img = np.concatenate((np_arr_b4, np_arr_b3, np_arr_b2), 2)\n",
+    "        #rgb_img = (255*((rgb_img)/3000)).astype('uint8')\n",
+    "        #plt.imshow(rgb_img)\n",
+    "        #plt.show()\n",
+    "\n",
+    "        # Normalized Difference Water Index (NDWI)\n",
+    "        # NDWI = ( G - NIR ) / ( G + NIR )\n",
+    "        ndwiG = (b3-b8)/(b3+b8) # Gao\n",
+    "        # NDWI = ( NIR - SWIR ) / ( NIR + SWIR )\n",
+    "        ndwiM = (b8-b11)/(b8+b11) # McFeeters\n",
+    "        # NDWI = ( G - SWIR ) / ( G + SWIR )\n",
+    "        mndwi = (b3-b11)/(b3+b11) # Modified NDWI\n",
+    "        water = ndwiG > -0.02\n",
+    "\n",
+    "        TSS1 = np.NAN\n",
+    "        Secchi1 = np.NAN\n",
+    "        TSS2 = np.NAN\n",
+    "        Secchi2 = np.NAN\n",
+    "        TSS3 = np.NAN\n",
+    "        Secchi3 = np.NAN\n",
+    "        TSS4 = np.NAN\n",
+    "        Ratio = np.NAN\n",
+    "\n",
+    "        TSS1 = (b3+b4)/2\n",
+    "        TSS1 = TSS1 * water\n",
+    "    #plt.imshow(TSS1 , cmap= \"summer\")\n",
+    "    #plt.colorbar(orientation=\"vertical\")\n",
+    "    #plt.show\n",
+    "        TSS1 = np.sum(TSS1) / np.sum(TSS1>0)\n",
+    "    #print(TSS1)\n",
+    "\n",
+    "        Secchi1 = (b2/b4)\n",
+    "        Secchi1 = Secchi1 * water\n",
+    "        Secchi1 = np.sum(Secchi1)/ np.sum(Secchi1>0)\n",
+    "\n",
+    "        TSS2 = (b3/b4)\n",
+    "        TSS2 = TSS2 * water\n",
+    "        TSS2 = np.sum(TSS2) / np.sum(TSS2>0)\n",
+    "\n",
+    "        Secchi2 = (b4/b3)\n",
+    "        Secchi2 = Secchi2 * water\n",
+    "        Secchi2 = np.sum(Secchi2)/ np.sum(Secchi2>0)\n",
+    "\n",
+    "        TSS3 = (b8/b3 , b8/b4)\n",
+    "        TSS3 = TSS3 * water\n",
+    "        TSS3 = np.sum(TSS3) / np.sum(TSS3>0)\n",
+    "\n",
+    "        Secchi3 = (b4/b2)+b2\n",
+    "        Secchi3 = Secchi3 * water\n",
+    "        Secchi3 = np.sum(Secchi3)/ np.sum(Secchi3>0)\n",
+    "\n",
+    "        TSS4 = (b4/b3)+b8\n",
+    "        TSS4 = TSS4 * water\n",
+    "        TSS4 = np.sum(TSS4) / np.sum(TSS4>0)\n",
+    "\n",
+    "        Ratio = (ndwiG/ndwiM)\n",
+    "        Ratio = Ratio * water\n",
+    "        Ratio = np.sum(Ratio)/ np.sum(Ratio>0) \n",
+    "\n",
+    "\n",
+    "        f = open(\"Hanover10day.txt\", \"a\")\n",
+    "        f.write(str(startDate) + \", \" + str(endDate) + \", \" + \n",
+    "                str(TSS1) + \", \" + str(Secchi1) + \", \" + \n",
+    "                str(TSS2) + \", \" + str(Secchi2) + \", \" + \n",
+    "                str(TSS3) + \", \" + str(Secchi3) + \", \" + \n",
+    "                str(TSS4) + \",\" + str(Ratio) + '\\n') \n",
+    "            \n",
+    "        f.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run over all dates\n",
+    "for i in range(len(dates)):\n",
+    "    pulldata(dates[\"start\"][i], dates[\"end\"][i])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I added this file.  It's nothing, but I used it to confirm that the US (Hanover) site isn't working.  I'm not sure what it is.  Everything looks good.

Anyway, confirm the acquisition dates if you can.  For example, at Balule, it appears that the image was taken 2024-06-16, but that was the first day of the range provided.

Also, the last date entered should be the day after (as in five days later, not four), as it stops before the date.  In other words, it is exclusive; [startDate, endDate).
